### PR TITLE
convert xml to dict to avoid AttributeError when using /MNT/ API (XML response)

### DIFF
--- a/ciscoisesdk/exceptions.py
+++ b/ciscoisesdk/exceptions.py
@@ -152,6 +152,7 @@ class ApiError(ciscoisesdkException):
 
         self.description = RESPONSE_CODES.get(self.status_code)
         """A description of the HTTP Response Code from the API docs."""
+
         super(ApiError, self).__init__(
             "[{status_code}]{status} - {message}{details}".format(
                 status_code=self.status_code,

--- a/ciscoisesdk/exceptions.py
+++ b/ciscoisesdk/exceptions.py
@@ -145,7 +145,8 @@ class ApiError(ciscoisesdkException):
             except ValueError:
                 logger.warning("Error parsing JSON response body")
         self.message = self.details.get("message") or\
-            self.details.get("response", {}).get("message") or self.details['mnt-rest-result']['description']\
+            self.details.get("response", {}).get("message") or\
+            self.details.get("mnt-rest-result", {}).get("description")\
             if self.details else None
         """The error message from the parsed API response."""
 


### PR DESCRIPTION
Closes #4 

Disclaimer: I'm a super novice at python :) ...  but I decided to try and solve my own issue. 

Looks like the problem here was I was trying to use the /MNT/ API and was getting back a HTTP 500. The response is in XML but it was expecting it to be a dict to get 'message'. I'm not exactly sure what 'message' looks like on the JSON responses, but after converting XMLtoDict I've taken `['mnt-rest-result']['internal-error-info']` and `['mnt-rest-result']['description']`

The result looks like this ... (not sure if this is ok or not in terms of consistency, but it at least informs the user whats going on). 

```
(Pdb) bwi.misc.get_sessions_by_mac('00:50:56:8F:78:4F').response

*** ciscoisesdk.exceptions.ApiError: [500] - Server has encountered error while processing the REST request
Error in generating XML output. Error message = Session data is not available for 00:50:56:8F:78:4F.
```

For reference `self.details` after going through xmltodict looks like this 

```
OrderedDict([('mnt-rest-result', OrderedDict([('http-code', '500'), ('cpm-code', '34110'), ('description', 'Server has encountered error while processing the REST request'), ('module-name', 'MnT'), ('internal-error-info', 'Error in generating XML output. Error message = Session data is not available for 00:50:56:8F:78:4F.'), ('requested-operation', 'Get By Type'), ('resource-id', 'N/A'), ('resource-name', 'N/A'), ('resource-type', 'RESTSDStatus'), ('status', 'SERVER_ERROR')]))])
```

Please provide feedback as needed :) 