### PR TITLE
Fixed some variable names and fixed a link.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.6] - 2022-27-10
+
+### Fixed
+
+- The following variable names have been repaired in v3_1_0.mics, v3_1_1.mics and v3_1_patch_1.mics
+  + The following variable was renamed from rec_ord_s to records
+  + The following variable was renamed from sec_ond_s to seconds
+  + The following variable was renamed from end_poi_ntm_ac to endpoint_mac
+  + The following variable was renamed from psn_nam_e to psn_name
+  + The following variable was renamed from rea_uth_typ_e to reauth_type
+  + The following variable was renamed from dis_con_nec_tty_pe to disconnect_type
+  + The following variable was renamed from end_poi_nti_p to endpoint_ip
+- The following url have been repaired in v3_1_0.mics.session_disconnect, v3_1_1.mics.session_disconnect and v3_1_patch_1.mics.session_disconnect
+  + From /admin/API/mnt/CoA/Disconnect>/{PSN_NAME}/{MAC}/{DISCONNECT_TYPE}/{NAS_IPV4}/{{ENDPOINT_IP}}
+    to /admin/API/mnt/CoA/Disconnect/{PSN_NAME}/{MAC}/{DISCONNECT_TYPE}/{NAS_IPV4}/{{ENDPOINT_IP}}
+
 ## [2.0.5] - 2022-12-10
 
 ### Fixed
@@ -364,4 +380,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [2.0.3]: https://github.com/CiscoISE/ciscoisesdk/compare/v2.0.2...v2.0.3
 [2.0.4]: https://github.com/CiscoISE/ciscoisesdk/compare/v2.0.3...v2.0.4
 [2.0.5]: https://github.com/CiscoISE/ciscoisesdk/compare/v2.0.4...v2.0.5
-[Unreleased]: https://github.com/CiscoISE/ciscoisesdk/compare/v2.0.5...develop
+[2.0.6]: https://github.com/CiscoISE/ciscoisesdk/compare/v2.0.5...v2.0.6
+[Unreleased]: https://github.com/CiscoISE/ciscoisesdk/compare/v2.0.6...develop

--- a/ciscoisesdk/api/v3_1_0/misc.py
+++ b/ciscoisesdk/api/v3_1_0/misc.py
@@ -859,16 +859,16 @@ class Misc(object):
 
     def get_authentication_status_by_mac(self,
                                          mac,
-                                         rec_ord_s,
-                                         sec_ond_s,
+                                         records,
+                                         seconds,
                                          headers=None,
                                          **query_parameters):
         """AuthenticationStatus by MAC.
 
         Args:
             mac(basestring): MAC path parameter.
-            sec_ond_s(basestring): SECONDS path parameter.
-            rec_ord_s(basestring): RECORDS path parameter.
+            seconds(basestring): SECONDS path parameter.
+            records(basestring): RECORDS path parameter.
             headers(dict): Dictionary of HTTP Headers to send with the Request
                 .
             **query_parameters: Additional query parameters (provides
@@ -903,9 +903,9 @@ class Misc(object):
             with_custom_headers = True
         check_type(mac, basestring,
                    may_be_none=False)
-        check_type(sec_ond_s, basestring,
+        check_type(seconds, basestring,
                    may_be_none=False)
-        check_type(rec_ord_s, basestring,
+        check_type(records, basestring,
                    may_be_none=False)
 
         _params = {
@@ -915,8 +915,8 @@ class Misc(object):
 
         path_params = {
             'MAC': mac,
-            'SECONDS': sec_ond_s,
-            'RECORDS': rec_ord_s,
+            'SECONDS': seconds,
+            'RECORDS': records,
         }
 
         e_url = ('/admin/API/mnt/AuthStatus/MACAddress/{MAC}/{SECONDS}/{RE'
@@ -931,17 +931,17 @@ class Misc(object):
         return self._object_factory('bpm_b26746235997bc32ace7d67d6987_v3_1_0', _api_response)
 
     def session_reauthentication_by_mac(self,
-                                        end_poi_ntm_ac,
-                                        psn_nam_e,
-                                        rea_uth_typ_e,
+                                        endpoint_mac,
+                                        psn_name,
+                                        reauth_type,
                                         headers=None,
                                         **query_parameters):
         """Session Reauthentication by MAC.
 
         Args:
-            psn_nam_e(basestring): PSN_NAME path parameter.
-            end_poi_ntm_ac(basestring): ENDPOINT_MAC path parameter.
-            rea_uth_typ_e(basestring): REAUTH_TYPE path parameter.
+            psn_name(basestring): PSN_NAME path parameter.
+            endpoint_mac(basestring): ENDPOINT_MAC path parameter.
+            reauth_type(basestring): REAUTH_TYPE path parameter.
             headers(dict): Dictionary of HTTP Headers to send with the Request
                 .
             **query_parameters: Additional query parameters (provides
@@ -974,11 +974,11 @@ class Misc(object):
         if headers:
             _headers.update(dict_of_str(headers))
             with_custom_headers = True
-        check_type(psn_nam_e, basestring,
+        check_type(psn_name, basestring,
                    may_be_none=False)
-        check_type(end_poi_ntm_ac, basestring,
+        check_type(endpoint_mac, basestring,
                    may_be_none=False)
-        check_type(rea_uth_typ_e, basestring,
+        check_type(reauth_type, basestring,
                    may_be_none=False)
 
         _params = {
@@ -987,9 +987,9 @@ class Misc(object):
         _params = dict_from_items_with_values(_params)
 
         path_params = {
-            'PSN_NAME': psn_nam_e,
-            'ENDPOINT_MAC': end_poi_ntm_ac,
-            'REAUTH_TYPE': rea_uth_typ_e,
+            'PSN_NAME': psn_name,
+            'ENDPOINT_MAC': endpoint_mac,
+            'REAUTH_TYPE': reauth_type,
         }
 
         e_url = ('/admin/API/mnt/CoA/Reauth/{PSN_NAME}/{ENDPOINT_MAC}/{REA'
@@ -1004,20 +1004,20 @@ class Misc(object):
         return self._object_factory('bpm_f73477346fb5e7097d915c7f0a99659_v3_1_0', _api_response)
 
     def session_disconnect(self,
-                           dis_con_nec_tty_pe,
-                           end_poi_nti_p,
+                           disconnect_type ,
+                           endpoint_ip,
                            mac,
                            nas_ipv4,
-                           psn_nam_e,
+                           psn_name,
                            headers=None,
                            **query_parameters):
         """Session Disconnect.
 
         Args:
-            end_poi_nti_p(basestring): ENDPOINT_IP path parameter.
-            psn_nam_e(basestring): PSN_NAME path parameter.
+            endpoint_ip(basestring): ENDPOINT_IP path parameter.
+            psn_name(basestring): PSN_NAME path parameter.
             mac(basestring): MAC path parameter.
-            dis_con_nec_tty_pe(basestring): DISCONNECT_TYPE path
+            disconnect_type (basestring): DISCONNECT_TYPE path
                 parameter.
             nas_ipv4(basestring): NAS_IPV4 path parameter.
             headers(dict): Dictionary of HTTP Headers to send with the Request
@@ -1052,13 +1052,13 @@ class Misc(object):
         if headers:
             _headers.update(dict_of_str(headers))
             with_custom_headers = True
-        check_type(end_poi_nti_p, basestring,
+        check_type(endpoint_ip, basestring,
                    may_be_none=False)
-        check_type(psn_nam_e, basestring,
+        check_type(psn_name, basestring,
                    may_be_none=False)
         check_type(mac, basestring,
                    may_be_none=False)
-        check_type(dis_con_nec_tty_pe, basestring,
+        check_type(disconnect_type , basestring,
                    may_be_none=False)
         check_type(nas_ipv4, basestring,
                    may_be_none=False)
@@ -1069,14 +1069,14 @@ class Misc(object):
         _params = dict_from_items_with_values(_params)
 
         path_params = {
-            'ENDPOINT_IP': end_poi_nti_p,
-            'PSN_NAME': psn_nam_e,
+            'ENDPOINT_IP': endpoint_ip,
+            'PSN_NAME': psn_name,
             'MAC': mac,
-            'DISCONNECT_TYPE': dis_con_nec_tty_pe,
+            'DISCONNECT_TYPE': disconnect_type ,
             'NAS_IPV4': nas_ipv4,
         }
 
-        e_url = ('/admin/API/mnt/CoA/Disconnect>/{PSN_NAME}/{MAC}/{DISCONN'
+        e_url = ('/admin/API/mnt/CoA/Disconnect/{PSN_NAME}/{MAC}/{DISCONN'
                  + 'ECT_TYPE}/{NAS_IPV4}/{{ENDPOINT_IP}}')
         endpoint_full_url = apply_path_params(e_url, path_params)
         if with_custom_headers:

--- a/ciscoisesdk/api/v3_1_1/misc.py
+++ b/ciscoisesdk/api/v3_1_1/misc.py
@@ -859,16 +859,16 @@ class Misc(object):
 
     def get_authentication_status_by_mac(self,
                                          mac,
-                                         rec_ord_s,
-                                         sec_ond_s,
+                                         records,
+                                         seconds,
                                          headers=None,
                                          **query_parameters):
         """AuthenticationStatus by MAC.
 
         Args:
             mac(basestring): MAC path parameter.
-            sec_ond_s(basestring): SECONDS path parameter.
-            rec_ord_s(basestring): RECORDS path parameter.
+            seconds(basestring): SECONDS path parameter.
+            records(basestring): RECORDS path parameter.
             headers(dict): Dictionary of HTTP Headers to send with the Request
                 .
             **query_parameters: Additional query parameters (provides
@@ -903,9 +903,9 @@ class Misc(object):
             with_custom_headers = True
         check_type(mac, basestring,
                    may_be_none=False)
-        check_type(sec_ond_s, basestring,
+        check_type(seconds, basestring,
                    may_be_none=False)
-        check_type(rec_ord_s, basestring,
+        check_type(records, basestring,
                    may_be_none=False)
 
         _params = {
@@ -915,8 +915,8 @@ class Misc(object):
 
         path_params = {
             'MAC': mac,
-            'SECONDS': sec_ond_s,
-            'RECORDS': rec_ord_s,
+            'SECONDS': seconds,
+            'RECORDS': records,
         }
 
         e_url = ('/admin/API/mnt/AuthStatus/MACAddress/{MAC}/{SECONDS}/{RE'
@@ -931,17 +931,17 @@ class Misc(object):
         return self._object_factory('bpm_b26746235997bc32ace7d67d6987_v3_1_1', _api_response)
 
     def session_reauthentication_by_mac(self,
-                                        end_poi_ntm_ac,
-                                        psn_nam_e,
-                                        rea_uth_typ_e,
+                                        endpoint_mac,
+                                        psn_name,
+                                        reauth_type,
                                         headers=None,
                                         **query_parameters):
         """Session Reauthentication by MAC.
 
         Args:
-            psn_nam_e(basestring): PSN_NAME path parameter.
-            end_poi_ntm_ac(basestring): ENDPOINT_MAC path parameter.
-            rea_uth_typ_e(basestring): REAUTH_TYPE path parameter.
+            psn_name(basestring): PSN_NAME path parameter.
+            endpoint_mac(basestring): ENDPOINT_MAC path parameter.
+            reauth_type(basestring): REAUTH_TYPE path parameter.
             headers(dict): Dictionary of HTTP Headers to send with the Request
                 .
             **query_parameters: Additional query parameters (provides
@@ -974,11 +974,11 @@ class Misc(object):
         if headers:
             _headers.update(dict_of_str(headers))
             with_custom_headers = True
-        check_type(psn_nam_e, basestring,
+        check_type(psn_name, basestring,
                    may_be_none=False)
-        check_type(end_poi_ntm_ac, basestring,
+        check_type(endpoint_mac, basestring,
                    may_be_none=False)
-        check_type(rea_uth_typ_e, basestring,
+        check_type(reauth_type, basestring,
                    may_be_none=False)
 
         _params = {
@@ -987,9 +987,9 @@ class Misc(object):
         _params = dict_from_items_with_values(_params)
 
         path_params = {
-            'PSN_NAME': psn_nam_e,
-            'ENDPOINT_MAC': end_poi_ntm_ac,
-            'REAUTH_TYPE': rea_uth_typ_e,
+            'PSN_NAME': psn_name,
+            'ENDPOINT_MAC': endpoint_mac,
+            'REAUTH_TYPE': reauth_type,
         }
 
         e_url = ('/admin/API/mnt/CoA/Reauth/{PSN_NAME}/{ENDPOINT_MAC}/{REA'
@@ -1004,20 +1004,20 @@ class Misc(object):
         return self._object_factory('bpm_f73477346fb5e7097d915c7f0a99659_v3_1_1', _api_response)
 
     def session_disconnect(self,
-                           dis_con_nec_tty_pe,
-                           end_poi_nti_p,
+                           disconnect_type ,
+                           endpoint_ip,
                            mac,
                            nas_ipv4,
-                           psn_nam_e,
+                           psn_name,
                            headers=None,
                            **query_parameters):
         """Session Disconnect.
 
         Args:
-            end_poi_nti_p(basestring): ENDPOINT_IP path parameter.
-            psn_nam_e(basestring): PSN_NAME path parameter.
+            endpoint_ip(basestring): ENDPOINT_IP path parameter.
+            psn_name(basestring): PSN_NAME path parameter.
             mac(basestring): MAC path parameter.
-            dis_con_nec_tty_pe(basestring): DISCONNECT_TYPE path
+            disconnect_type (basestring): DISCONNECT_TYPE path
                 parameter.
             nas_ipv4(basestring): NAS_IPV4 path parameter.
             headers(dict): Dictionary of HTTP Headers to send with the Request
@@ -1052,13 +1052,13 @@ class Misc(object):
         if headers:
             _headers.update(dict_of_str(headers))
             with_custom_headers = True
-        check_type(end_poi_nti_p, basestring,
+        check_type(endpoint_ip, basestring,
                    may_be_none=False)
-        check_type(psn_nam_e, basestring,
+        check_type(psn_name, basestring,
                    may_be_none=False)
         check_type(mac, basestring,
                    may_be_none=False)
-        check_type(dis_con_nec_tty_pe, basestring,
+        check_type(disconnect_type , basestring,
                    may_be_none=False)
         check_type(nas_ipv4, basestring,
                    may_be_none=False)
@@ -1069,14 +1069,14 @@ class Misc(object):
         _params = dict_from_items_with_values(_params)
 
         path_params = {
-            'ENDPOINT_IP': end_poi_nti_p,
-            'PSN_NAME': psn_nam_e,
+            'ENDPOINT_IP': endpoint_ip,
+            'PSN_NAME': psn_name,
             'MAC': mac,
-            'DISCONNECT_TYPE': dis_con_nec_tty_pe,
+            'DISCONNECT_TYPE': disconnect_type ,
             'NAS_IPV4': nas_ipv4,
         }
 
-        e_url = ('/admin/API/mnt/CoA/Disconnect>/{PSN_NAME}/{MAC}/{DISCONN'
+        e_url = ('/admin/API/mnt/CoA/Disconnect/{PSN_NAME}/{MAC}/{DISCONN'
                  + 'ECT_TYPE}/{NAS_IPV4}/{{ENDPOINT_IP}}')
         endpoint_full_url = apply_path_params(e_url, path_params)
         if with_custom_headers:

--- a/ciscoisesdk/api/v3_1_patch_1/misc.py
+++ b/ciscoisesdk/api/v3_1_patch_1/misc.py
@@ -859,16 +859,16 @@ class Misc(object):
 
     def get_authentication_status_by_mac(self,
                                          mac,
-                                         rec_ord_s,
-                                         sec_ond_s,
+                                         records,
+                                         seconds,
                                          headers=None,
                                          **query_parameters):
         """AuthenticationStatus by MAC.
 
         Args:
             mac(basestring): MAC path parameter.
-            sec_ond_s(basestring): SECONDS path parameter.
-            rec_ord_s(basestring): RECORDS path parameter.
+            seconds(basestring): SECONDS path parameter.
+            records(basestring): RECORDS path parameter.
             headers(dict): Dictionary of HTTP Headers to send with the Request
                 .
             **query_parameters: Additional query parameters (provides
@@ -903,9 +903,9 @@ class Misc(object):
             with_custom_headers = True
         check_type(mac, basestring,
                    may_be_none=False)
-        check_type(sec_ond_s, basestring,
+        check_type(seconds, basestring,
                    may_be_none=False)
-        check_type(rec_ord_s, basestring,
+        check_type(records, basestring,
                    may_be_none=False)
 
         _params = {
@@ -915,8 +915,8 @@ class Misc(object):
 
         path_params = {
             'MAC': mac,
-            'SECONDS': sec_ond_s,
-            'RECORDS': rec_ord_s,
+            'SECONDS': seconds,
+            'RECORDS': records,
         }
 
         e_url = ('/admin/API/mnt/AuthStatus/MACAddress/{MAC}/{SECONDS}/{RE'
@@ -931,17 +931,17 @@ class Misc(object):
         return self._object_factory('bpm_b26746235997bc32ace7d67d6987_v3_1_patch_1', _api_response)
 
     def session_reauthentication_by_mac(self,
-                                        end_poi_ntm_ac,
-                                        psn_nam_e,
-                                        rea_uth_typ_e,
+                                        endpoint_mac,
+                                        psn_name,
+                                        reauth_type,
                                         headers=None,
                                         **query_parameters):
         """Session Reauthentication by MAC.
 
         Args:
-            psn_nam_e(basestring): PSN_NAME path parameter.
-            end_poi_ntm_ac(basestring): ENDPOINT_MAC path parameter.
-            rea_uth_typ_e(basestring): REAUTH_TYPE path parameter.
+            psn_name(basestring): PSN_NAME path parameter.
+            endpoint_mac(basestring): ENDPOINT_MAC path parameter.
+            reauth_type(basestring): REAUTH_TYPE path parameter.
             headers(dict): Dictionary of HTTP Headers to send with the Request
                 .
             **query_parameters: Additional query parameters (provides
@@ -974,11 +974,11 @@ class Misc(object):
         if headers:
             _headers.update(dict_of_str(headers))
             with_custom_headers = True
-        check_type(psn_nam_e, basestring,
+        check_type(psn_name, basestring,
                    may_be_none=False)
-        check_type(end_poi_ntm_ac, basestring,
+        check_type(endpoint_mac, basestring,
                    may_be_none=False)
-        check_type(rea_uth_typ_e, basestring,
+        check_type(reauth_type, basestring,
                    may_be_none=False)
 
         _params = {
@@ -987,9 +987,9 @@ class Misc(object):
         _params = dict_from_items_with_values(_params)
 
         path_params = {
-            'PSN_NAME': psn_nam_e,
-            'ENDPOINT_MAC': end_poi_ntm_ac,
-            'REAUTH_TYPE': rea_uth_typ_e,
+            'PSN_NAME': psn_name,
+            'ENDPOINT_MAC': endpoint_mac,
+            'REAUTH_TYPE': reauth_type,
         }
 
         e_url = ('/admin/API/mnt/CoA/Reauth/{PSN_NAME}/{ENDPOINT_MAC}/{REA'
@@ -1004,20 +1004,20 @@ class Misc(object):
         return self._object_factory('bpm_f73477346fb5e7097d915c7f0a99659_v3_1_patch_1', _api_response)
 
     def session_disconnect(self,
-                           dis_con_nec_tty_pe,
-                           end_poi_nti_p,
+                           disconnect_type ,
+                           endpoint_ip,
                            mac,
                            nas_ipv4,
-                           psn_nam_e,
+                           psn_name,
                            headers=None,
                            **query_parameters):
         """Session Disconnect.
 
         Args:
-            end_poi_nti_p(basestring): ENDPOINT_IP path parameter.
-            psn_nam_e(basestring): PSN_NAME path parameter.
+            endpoint_ip(basestring): ENDPOINT_IP path parameter.
+            psn_name(basestring): PSN_NAME path parameter.
             mac(basestring): MAC path parameter.
-            dis_con_nec_tty_pe(basestring): DISCONNECT_TYPE path
+            disconnect_type (basestring): DISCONNECT_TYPE path
                 parameter.
             nas_ipv4(basestring): NAS_IPV4 path parameter.
             headers(dict): Dictionary of HTTP Headers to send with the Request
@@ -1052,13 +1052,13 @@ class Misc(object):
         if headers:
             _headers.update(dict_of_str(headers))
             with_custom_headers = True
-        check_type(end_poi_nti_p, basestring,
+        check_type(endpoint_ip, basestring,
                    may_be_none=False)
-        check_type(psn_nam_e, basestring,
+        check_type(psn_name, basestring,
                    may_be_none=False)
         check_type(mac, basestring,
                    may_be_none=False)
-        check_type(dis_con_nec_tty_pe, basestring,
+        check_type(disconnect_type , basestring,
                    may_be_none=False)
         check_type(nas_ipv4, basestring,
                    may_be_none=False)
@@ -1069,14 +1069,14 @@ class Misc(object):
         _params = dict_from_items_with_values(_params)
 
         path_params = {
-            'ENDPOINT_IP': end_poi_nti_p,
-            'PSN_NAME': psn_nam_e,
+            'ENDPOINT_IP': endpoint_ip,
+            'PSN_NAME': psn_name,
             'MAC': mac,
-            'DISCONNECT_TYPE': dis_con_nec_tty_pe,
+            'DISCONNECT_TYPE': disconnect_type ,
             'NAS_IPV4': nas_ipv4,
         }
 
-        e_url = ('/admin/API/mnt/CoA/Disconnect>/{PSN_NAME}/{MAC}/{DISCONN'
+        e_url = ('/admin/API/mnt/CoA/Disconnect/{PSN_NAME}/{MAC}/{DISCONN'
                  + 'ECT_TYPE}/{NAS_IPV4}/{{ENDPOINT_IP}}')
         endpoint_full_url = apply_path_params(e_url, path_params)
         if with_custom_headers:

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -8,11 +8,45 @@ Changelog <https://keepachangelog.com/en/1.0.0/>`__, and this project
 adheres to `Semantic
 Versioning <https://semver.org/spec/v2.0.0.html>`__.
 
-`Unreleased <https://github.com/CiscoISE/ciscoisesdk/compare/v2.0.5...develop>`__
+`Unreleased <https://github.com/CiscoISE/ciscoisesdk/compare/v2.0.6...develop>`__
 ---------------------------------------------------------------------------------
+
+`2.0.6 <https://github.com/CiscoISE/ciscoisesdk/compare/v2.0.5...v2.0.6>`__ - 2022-27-10
+----------------------------------------------------------------------------------------
+
+Fixed
+~~~~~
+
+-  The following variable names have been repaired in v3_1_0.mics,
+   v3_1_1.mics and v3_1_patch_1.mics
+
+   -  The following variable was renamed from rec_ord_s to records
+   -  The following variable was renamed from sec_ond_s to seconds
+   -  The following variable was renamed from end_poi_ntm_ac to
+      endpoint_mac
+   -  The following variable was renamed from psn_nam_e to psn_name
+   -  The following variable was renamed from rea_uth_typ_e to
+      reauth_type
+   -  The following variable was renamed from dis_con_nec_tty_pe to
+      disconnect_type
+   -  The following variable was renamed from end_poi_nti_p to
+      endpoint_ip
+
+-  The following url have been repaired in
+   v3_1_0.mics.session_disconnect, v3_1_1.mics.session_disconnect and
+   v3_1_patch_1.mics.session_disconnect
+
+   -  From
+      /admin/API/mnt/CoA/Disconnect>/{PSN_NAME}/{MAC}/{DISCONNECT_TYPE}/{NAS_IPV4}/{{ENDPOINT_IP}}
+      to
+      /admin/API/mnt/CoA/Disconnect/{PSN_NAME}/{MAC}/{DISCONNECT_TYPE}/{NAS_IPV4}/{{ENDPOINT_IP}}
+
+.. _section-1:
 
 `2.0.5 <https://github.com/CiscoISE/ciscoisesdk/compare/v2.0.4...v2.0.5>`__ - 2022-12-10
 ----------------------------------------------------------------------------------------
+
+.. _fixed-1:
 
 Fixed
 ~~~~~
@@ -24,19 +58,19 @@ Fixed
    network_access_network_conditions.update_network_access_network_condition_by_id
    request 3.1_patch_1 and 3.1.1
 
-.. _section-1:
+.. _section-2:
 
 `2.0.4 <https://github.com/CiscoISE/ciscoisesdk/compare/v2.0.3...v2.0.4>`__ - 2022-07-11
 ----------------------------------------------------------------------------------------
 
-.. _fixed-1:
+.. _fixed-2:
 
 Fixed
 ~~~~~
 
 -  Update check_type to pass an instance of a list.
 
-.. _section-2:
+.. _section-3:
 
 `2.0.3 <https://github.com/CiscoISE/ciscoisesdk/compare/v2.0.2...v2.0.3>`__ - 2022-06-07
 ----------------------------------------------------------------------------------------
@@ -47,12 +81,12 @@ Changed
 -  Default ISE DEFAULT_VERSION to 3.1_Patch_1
 -  Update documentation to use ISE v3.1_Patch_1
 
-.. _section-3:
+.. _section-4:
 
 `2.0.2 <https://github.com/CiscoISE/ciscoisesdk/compare/v2.0.1...v2.0.2>`__ - 2022-05-02
 ----------------------------------------------------------------------------------------
 
-.. _fixed-2:
+.. _fixed-3:
 
 Fixed
 ~~~~~
@@ -61,7 +95,7 @@ Fixed
    when they attempt to get_next_page. Previous version only captured
    and ignored 404 Not Found and 400 Bad Request.
 
-.. _section-4:
+.. _section-5:
 
 `2.0.1 <https://github.com/CiscoISE/ciscoisesdk/compare/v2.0.0...v2.0.1>`__ - 2022-03-24
 ----------------------------------------------------------------------------------------
@@ -111,7 +145,7 @@ Changed
    -  ciscoisesdk.api.v3_1_1.support_bundle_download.SupportBundleDownload.download_support_bundle
    -  ciscoisesdk.api.v3_1_1.support_bundle_download.SupportBundleDownload.download
 
-.. _section-5:
+.. _section-6:
 
 `2.0.0 <https://github.com/CiscoISE/ciscoisesdk/compare/v1.5.1...v2.0.0>`__ - 2022-03-24
 ----------------------------------------------------------------------------------------
@@ -123,7 +157,7 @@ Removed
    and ``RestSession``.
 -  Drop ISE version 3.0.0 support.
 
-.. _section-6:
+.. _section-7:
 
 `1.5.1 <https://github.com/CiscoISE/ciscoisesdk/compare/v1.5.0...v1.5.1>`__ - 2022-02-25
 ----------------------------------------------------------------------------------------
@@ -135,7 +169,7 @@ Changed
 
 -  Update docstring documentation of modules and functions.
 
-.. _section-7:
+.. _section-8:
 
 `1.5.0 <https://github.com/CiscoISE/ciscoisesdk/compare/v1.4.2...v1.5.0>`__ - 2022-02-23
 ----------------------------------------------------------------------------------------
@@ -248,7 +282,7 @@ Added
    ``RestSession``.
 -  New ``additional_data`` property in ``ApiError``.
 
-.. _fixed-3:
+.. _fixed-4:
 
 Fixed
 ~~~~~
@@ -257,12 +291,12 @@ Fixed
    variables set after the module is imported, and not only before it.
 -  Fixed the docstring tables of the API modules.
 
-.. _section-8:
+.. _section-9:
 
 `1.4.2 <https://github.com/CiscoISE/ciscoisesdk/compare/v1.4.1...v1.4.2>`__ - 2022-02-18
 ----------------------------------------------------------------------------------------
 
-.. _fixed-4:
+.. _fixed-5:
 
 Fixed
 ~~~~~
@@ -271,7 +305,7 @@ Fixed
    when they attempt to get_next_page. Previous version only captured
    and ignored 404 Not Found.
 
-.. _section-9:
+.. _section-10:
 
 `1.4.1 <https://github.com/CiscoISE/ciscoisesdk/compare/v1.4.0...v1.4.1>`__ - 2022-01-20
 ----------------------------------------------------------------------------------------
@@ -284,7 +318,7 @@ Changed
 -  Update module inner documentation.
 -  Downgrade requirements file to use poetry versions.
 
-.. _section-10:
+.. _section-11:
 
 `1.4.0 <https://github.com/CiscoISE/ciscoisesdk/compare/v1.3.1...v1.4.0>`__ - 2022-01-19
 ----------------------------------------------------------------------------------------
@@ -296,7 +330,7 @@ Changed
 
 -  Update requirements
 
-.. _fixed-5:
+.. _fixed-6:
 
 Fixed
 ~~~~~
@@ -304,7 +338,7 @@ Fixed
 -  Update pagination, get_next_page inner logic and location from utils
    to pagination.
 
-.. _section-11:
+.. _section-12:
 
 `1.3.1 <https://github.com/CiscoISE/ciscoisesdk/compare/v1.3.0...v1.3.1>`__ - 2021-12-13
 ----------------------------------------------------------------------------------------
@@ -316,7 +350,7 @@ Changed
 
 -  Fixes utils.get_next_page generator starting default page
 
-.. _section-12:
+.. _section-13:
 
 `1.3.0 <https://github.com/CiscoISE/ciscoisesdk/compare/v1.2.0...v1.3.0>`__ - 2021-12-13
 ----------------------------------------------------------------------------------------
@@ -350,7 +384,7 @@ Removed
 -  Removes replication_status module
 -  Removes sync_ise_node module
 
-.. _section-13:
+.. _section-14:
 
 `1.2.0 <https://github.com/CiscoISE/ciscoisesdk/compare/v1.1.0...v1.2.0>`__ - 2021-11-24
 ----------------------------------------------------------------------------------------
@@ -379,7 +413,7 @@ Removed
 
 -  Removes link of 3.1.0 modules to 3.0.0 version
 
-.. _section-14:
+.. _section-15:
 
 `1.1.0 <https://github.com/CiscoISE/ciscoisesdk/compare/v1.0.1...v1.1.0>`__ - 2021-10-22
 ----------------------------------------------------------------------------------------
@@ -399,7 +433,7 @@ Changed
 -  Default ISE DEFAULT_VERSION to 3.1.0
 -  Update documentation to use ISE v3.1.0
 
-.. _section-15:
+.. _section-16:
 
 `1.0.1 <https://github.com/CiscoISE/ciscoisesdk/compare/v1.0.0...v1.0.1>`__ - 2021-09-14
 ----------------------------------------------------------------------------------------
@@ -411,7 +445,7 @@ Changed
 
 -  Disabled warnings of urllib3 if verify is False
 
-.. _section-16:
+.. _section-17:
 
 `1.0.0 <https://github.com/CiscoISE/ciscoisesdk/compare/v0.5.1...v1.0.0>`__ - 2021-07-21
 ----------------------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ciscoisesdk"
-version = "2.0.5"
+version = "2.0.6"
 description = "Cisco Identity Services Engine Platform SDK"
 authors = ["Jose Bogarin Solano <jbogarin@altus.cr>", "William Astorga <wastorga@altus.cr>"]
 license = "MIT"

--- a/tests/api/v3_1_0/test_misc.py
+++ b/tests/api/v3_1_0/test_misc.py
@@ -708,8 +708,8 @@ def is_valid_get_authentication_status_by_mac(json_schema_validate, obj):
 def get_authentication_status_by_mac(api):
     endpoint_result = api.misc.get_authentication_status_by_mac(
         mac='string',
-        rec_ord_s='string',
-        sec_ond_s='string'
+        sseconds='string',
+        seconds='string'
     )
     return endpoint_result
 
@@ -730,8 +730,8 @@ def test_get_authentication_status_by_mac(api, validator):
 def get_authentication_status_by_mac_default(api):
     endpoint_result = api.misc.get_authentication_status_by_mac(
         mac='string',
-        rec_ord_s='string',
-        sec_ond_s='string'
+        sseconds='string',
+        seconds='string'
     )
     return endpoint_result
 
@@ -762,9 +762,9 @@ def is_valid_session_reauthentication_by_mac(json_schema_validate, obj):
 
 def session_reauthentication_by_mac(api):
     endpoint_result = api.misc.session_reauthentication_by_mac(
-        end_poi_ntm_ac='string',
-        psn_nam_e='string',
-        rea_uth_typ_e='string'
+        endpoint_mac='string',
+        psn_name='string',
+        reauth_type='string'
     )
     return endpoint_result
 
@@ -784,9 +784,9 @@ def test_session_reauthentication_by_mac(api, validator):
 
 def session_reauthentication_by_mac_default(api):
     endpoint_result = api.misc.session_reauthentication_by_mac(
-        end_poi_ntm_ac='string',
-        psn_nam_e='string',
-        rea_uth_typ_e='string'
+        endpoint_mac='string',
+        psn_name='string',
+        reauth_type='string'
     )
     return endpoint_result
 
@@ -817,11 +817,11 @@ def is_valid_session_disconnect(json_schema_validate, obj):
 
 def session_disconnect(api):
     endpoint_result = api.misc.session_disconnect(
-        dis_con_nec_tty_pe='string',
-        end_poi_nti_p='string',
+        disconnect_type='string',
+        endpoint_ip='string',
         mac='string',
         nas_ipv4='string',
-        psn_nam_e='string'
+        psn_name='string'
     )
     return endpoint_result
 
@@ -841,11 +841,11 @@ def test_session_disconnect(api, validator):
 
 def session_disconnect_default(api):
     endpoint_result = api.misc.session_disconnect(
-        dis_con_nec_tty_pe='string',
-        end_poi_nti_p='string',
+        disconnect_type='string',
+        endpoint_ip='string',
         mac='string',
         nas_ipv4='string',
-        psn_nam_e='string'
+        psn_name='string'
     )
     return endpoint_result
 

--- a/tests/api/v3_1_1/test_misc.py
+++ b/tests/api/v3_1_1/test_misc.py
@@ -708,8 +708,8 @@ def is_valid_get_authentication_status_by_mac(json_schema_validate, obj):
 def get_authentication_status_by_mac(api):
     endpoint_result = api.misc.get_authentication_status_by_mac(
         mac='string',
-        rec_ord_s='string',
-        sec_ond_s='string'
+        sseconds='string',
+        seconds='string'
     )
     return endpoint_result
 
@@ -730,8 +730,8 @@ def test_get_authentication_status_by_mac(api, validator):
 def get_authentication_status_by_mac_default(api):
     endpoint_result = api.misc.get_authentication_status_by_mac(
         mac='string',
-        rec_ord_s='string',
-        sec_ond_s='string'
+        sseconds='string',
+        seconds='string'
     )
     return endpoint_result
 
@@ -762,9 +762,9 @@ def is_valid_session_reauthentication_by_mac(json_schema_validate, obj):
 
 def session_reauthentication_by_mac(api):
     endpoint_result = api.misc.session_reauthentication_by_mac(
-        end_poi_ntm_ac='string',
-        psn_nam_e='string',
-        rea_uth_typ_e='string'
+        endpoint_mac='string',
+        psn_name='string',
+        reauth_type='string'
     )
     return endpoint_result
 
@@ -784,9 +784,9 @@ def test_session_reauthentication_by_mac(api, validator):
 
 def session_reauthentication_by_mac_default(api):
     endpoint_result = api.misc.session_reauthentication_by_mac(
-        end_poi_ntm_ac='string',
-        psn_nam_e='string',
-        rea_uth_typ_e='string'
+        endpoint_mac='string',
+        psn_name='string',
+        reauth_type='string'
     )
     return endpoint_result
 
@@ -817,11 +817,11 @@ def is_valid_session_disconnect(json_schema_validate, obj):
 
 def session_disconnect(api):
     endpoint_result = api.misc.session_disconnect(
-        dis_con_nec_tty_pe='string',
-        end_poi_nti_p='string',
+        disconnect_type='string',
+        endpoint_ip='string',
         mac='string',
         nas_ipv4='string',
-        psn_nam_e='string'
+        psn_name='string'
     )
     return endpoint_result
 
@@ -841,11 +841,11 @@ def test_session_disconnect(api, validator):
 
 def session_disconnect_default(api):
     endpoint_result = api.misc.session_disconnect(
-        dis_con_nec_tty_pe='string',
-        end_poi_nti_p='string',
+        disconnect_type='string',
+        endpoint_ip='string',
         mac='string',
         nas_ipv4='string',
-        psn_nam_e='string'
+        psn_name='string'
     )
     return endpoint_result
 

--- a/tests/api/v3_1_patch_1/test_misc.py
+++ b/tests/api/v3_1_patch_1/test_misc.py
@@ -708,8 +708,8 @@ def is_valid_get_authentication_status_by_mac(json_schema_validate, obj):
 def get_authentication_status_by_mac(api):
     endpoint_result = api.misc.get_authentication_status_by_mac(
         mac='string',
-        rec_ord_s='string',
-        sec_ond_s='string'
+        sseconds='string',
+        seconds='string'
     )
     return endpoint_result
 
@@ -730,8 +730,8 @@ def test_get_authentication_status_by_mac(api, validator):
 def get_authentication_status_by_mac_default(api):
     endpoint_result = api.misc.get_authentication_status_by_mac(
         mac='string',
-        rec_ord_s='string',
-        sec_ond_s='string'
+        sseconds='string',
+        seconds='string'
     )
     return endpoint_result
 
@@ -762,9 +762,9 @@ def is_valid_session_reauthentication_by_mac(json_schema_validate, obj):
 
 def session_reauthentication_by_mac(api):
     endpoint_result = api.misc.session_reauthentication_by_mac(
-        end_poi_ntm_ac='string',
-        psn_nam_e='string',
-        rea_uth_typ_e='string'
+        endpoint_mac='string',
+        psn_name='string',
+        reauth_type='string'
     )
     return endpoint_result
 
@@ -784,9 +784,9 @@ def test_session_reauthentication_by_mac(api, validator):
 
 def session_reauthentication_by_mac_default(api):
     endpoint_result = api.misc.session_reauthentication_by_mac(
-        end_poi_ntm_ac='string',
-        psn_nam_e='string',
-        rea_uth_typ_e='string'
+        endpoint_mac='string',
+        psn_name='string',
+        reauth_type='string'
     )
     return endpoint_result
 
@@ -817,11 +817,11 @@ def is_valid_session_disconnect(json_schema_validate, obj):
 
 def session_disconnect(api):
     endpoint_result = api.misc.session_disconnect(
-        dis_con_nec_tty_pe='string',
-        end_poi_nti_p='string',
+        disconnect_type='string',
+        endpoint_ip='string',
         mac='string',
         nas_ipv4='string',
-        psn_nam_e='string'
+        psn_name='string'
     )
     return endpoint_result
 
@@ -841,11 +841,11 @@ def test_session_disconnect(api, validator):
 
 def session_disconnect_default(api):
     endpoint_result = api.misc.session_disconnect(
-        dis_con_nec_tty_pe='string',
-        end_poi_nti_p='string',
+        disconnect_type='string',
+        endpoint_ip='string',
         mac='string',
         nas_ipv4='string',
-        psn_nam_e='string'
+        psn_name='string'
     )
     return endpoint_result
 


### PR DESCRIPTION
- The following variable names have been repaired in v3_1_0.mics, v3_1_1.mics and v3_1_patch_1.mics
  + The following variable was renamed from rec_ord_s to records
  + The following variable was renamed from sec_ond_s to seconds
  + The following variable was renamed from end_poi_ntm_ac to endpoint_mac
  + The following variable was renamed from psn_nam_e to psn_name
  + The following variable was renamed from rea_uth_typ_e to reauth_type
  + The following variable was renamed from dis_con_nec_tty_pe to disconnect_type
  + The following variable was renamed from end_poi_nti_p to endpoint_ip
- The following url have been repaired in v3_1_0.mics.session_disconnect, v3_1_1.mics.session_disconnect and v3_1_patch_1.mics.session_disconnect
  + From /admin/API/mnt/CoA/Disconnect>/{PSN_NAME}/{MAC}/{DISCONNECT_TYPE}/{NAS_IPV4}/{{ENDPOINT_IP}} to /admin/API/mnt/CoA/Disconnect/{PSN_NAME}/{MAC}/{DISCONNECT_TYPE}/{NAS_IPV4}/{{ENDPOINT_IP}}