### PR TITLE
- The following url have been repaired in v3_1_0.mics.session_disconn…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.7] - 2022-01-11
+
+### Fixed
+- The following url have been repaired in v3_1_0.mics.session_disconnect, v3_1_1.mics.session_disconnect and v3_1_patch_1.mics.session_disconnect
+  + From /admin/API/mnt/CoA/Disconnect/{PSN_NAME}/{MAC}/{DISCONNECT_TYPE}/{NAS_IPV4}/{{ENDPOINT_IP}}
+    to /admin/API/mnt/CoA/Disconnect/{PSN_NAME}/{MAC}/{DISCONNECT_TYPE}/{NAS_IPV4}/{ENDPOINT_IP}
+
 ## [2.0.6] - 2022-27-10
 
 ### Fixed
@@ -381,4 +388,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [2.0.4]: https://github.com/CiscoISE/ciscoisesdk/compare/v2.0.3...v2.0.4
 [2.0.5]: https://github.com/CiscoISE/ciscoisesdk/compare/v2.0.4...v2.0.5
 [2.0.6]: https://github.com/CiscoISE/ciscoisesdk/compare/v2.0.5...v2.0.6
-[Unreleased]: https://github.com/CiscoISE/ciscoisesdk/compare/v2.0.6...develop
+[2.0.7]: https://github.com/CiscoISE/ciscoisesdk/compare/v2.0.6...v2.0.7
+[Unreleased]: https://github.com/CiscoISE/ciscoisesdk/compare/v2.0.7...develop

--- a/ciscoisesdk/api/v3_1_0/misc.py
+++ b/ciscoisesdk/api/v3_1_0/misc.py
@@ -1077,7 +1077,7 @@ class Misc(object):
         }
 
         e_url = ('/admin/API/mnt/CoA/Disconnect/{PSN_NAME}/{MAC}/{DISCONN'
-                 + 'ECT_TYPE}/{NAS_IPV4}/{{ENDPOINT_IP}}')
+                 + 'ECT_TYPE}/{NAS_IPV4}/{ENDPOINT_IP}')
         endpoint_full_url = apply_path_params(e_url, path_params)
         if with_custom_headers:
             _api_response = self._session.get(endpoint_full_url, params=_params,

--- a/ciscoisesdk/api/v3_1_1/misc.py
+++ b/ciscoisesdk/api/v3_1_1/misc.py
@@ -1077,7 +1077,7 @@ class Misc(object):
         }
 
         e_url = ('/admin/API/mnt/CoA/Disconnect/{PSN_NAME}/{MAC}/{DISCONN'
-                 + 'ECT_TYPE}/{NAS_IPV4}/{{ENDPOINT_IP}}')
+                 + 'ECT_TYPE}/{NAS_IPV4}/{ENDPOINT_IP}')
         endpoint_full_url = apply_path_params(e_url, path_params)
         if with_custom_headers:
             _api_response = self._session.get(endpoint_full_url, params=_params,

--- a/ciscoisesdk/api/v3_1_patch_1/misc.py
+++ b/ciscoisesdk/api/v3_1_patch_1/misc.py
@@ -1077,7 +1077,7 @@ class Misc(object):
         }
 
         e_url = ('/admin/API/mnt/CoA/Disconnect/{PSN_NAME}/{MAC}/{DISCONN'
-                 + 'ECT_TYPE}/{NAS_IPV4}/{{ENDPOINT_IP}}')
+                 + 'ECT_TYPE}/{NAS_IPV4}/{ENDPOINT_IP}')
         endpoint_full_url = apply_path_params(e_url, path_params)
         if with_custom_headers:
             _api_response = self._session.get(endpoint_full_url, params=_params,

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -8,11 +8,30 @@ Changelog <https://keepachangelog.com/en/1.0.0/>`__, and this project
 adheres to `Semantic
 Versioning <https://semver.org/spec/v2.0.0.html>`__.
 
-`Unreleased <https://github.com/CiscoISE/ciscoisesdk/compare/v2.0.6...develop>`__
+`Unreleased <https://github.com/CiscoISE/ciscoisesdk/compare/v2.0.7...develop>`__
 ---------------------------------------------------------------------------------
+
+`2.0.7 <https://github.com/CiscoISE/ciscoisesdk/compare/v2.0.6...v2.0.7>`__ - 2022-01-11
+----------------------------------------------------------------------------------------
+
+Fixed
+~~~~~
+
+-  The following url have been repaired in
+   v3_1_0.mics.session_disconnect, v3_1_1.mics.session_disconnect and
+   v3_1_patch_1.mics.session_disconnect
+
+   -  From
+      /admin/API/mnt/CoA/Disconnect/{PSN_NAME}/{MAC}/{DISCONNECT_TYPE}/{NAS_IPV4}/{{ENDPOINT_IP}}
+      to
+      /admin/API/mnt/CoA/Disconnect/{PSN_NAME}/{MAC}/{DISCONNECT_TYPE}/{NAS_IPV4}/{ENDPOINT_IP}
+
+.. _section-1:
 
 `2.0.6 <https://github.com/CiscoISE/ciscoisesdk/compare/v2.0.5...v2.0.6>`__ - 2022-27-10
 ----------------------------------------------------------------------------------------
+
+.. _fixed-1:
 
 Fixed
 ~~~~~
@@ -41,12 +60,12 @@ Fixed
       to
       /admin/API/mnt/CoA/Disconnect/{PSN_NAME}/{MAC}/{DISCONNECT_TYPE}/{NAS_IPV4}/{{ENDPOINT_IP}}
 
-.. _section-1:
+.. _section-2:
 
 `2.0.5 <https://github.com/CiscoISE/ciscoisesdk/compare/v2.0.4...v2.0.5>`__ - 2022-12-10
 ----------------------------------------------------------------------------------------
 
-.. _fixed-1:
+.. _fixed-2:
 
 Fixed
 ~~~~~
@@ -58,19 +77,19 @@ Fixed
    network_access_network_conditions.update_network_access_network_condition_by_id
    request 3.1_patch_1 and 3.1.1
 
-.. _section-2:
+.. _section-3:
 
 `2.0.4 <https://github.com/CiscoISE/ciscoisesdk/compare/v2.0.3...v2.0.4>`__ - 2022-07-11
 ----------------------------------------------------------------------------------------
 
-.. _fixed-2:
+.. _fixed-3:
 
 Fixed
 ~~~~~
 
 -  Update check_type to pass an instance of a list.
 
-.. _section-3:
+.. _section-4:
 
 `2.0.3 <https://github.com/CiscoISE/ciscoisesdk/compare/v2.0.2...v2.0.3>`__ - 2022-06-07
 ----------------------------------------------------------------------------------------
@@ -81,12 +100,12 @@ Changed
 -  Default ISE DEFAULT_VERSION to 3.1_Patch_1
 -  Update documentation to use ISE v3.1_Patch_1
 
-.. _section-4:
+.. _section-5:
 
 `2.0.2 <https://github.com/CiscoISE/ciscoisesdk/compare/v2.0.1...v2.0.2>`__ - 2022-05-02
 ----------------------------------------------------------------------------------------
 
-.. _fixed-3:
+.. _fixed-4:
 
 Fixed
 ~~~~~
@@ -95,7 +114,7 @@ Fixed
    when they attempt to get_next_page. Previous version only captured
    and ignored 404 Not Found and 400 Bad Request.
 
-.. _section-5:
+.. _section-6:
 
 `2.0.1 <https://github.com/CiscoISE/ciscoisesdk/compare/v2.0.0...v2.0.1>`__ - 2022-03-24
 ----------------------------------------------------------------------------------------
@@ -145,7 +164,7 @@ Changed
    -  ciscoisesdk.api.v3_1_1.support_bundle_download.SupportBundleDownload.download_support_bundle
    -  ciscoisesdk.api.v3_1_1.support_bundle_download.SupportBundleDownload.download
 
-.. _section-6:
+.. _section-7:
 
 `2.0.0 <https://github.com/CiscoISE/ciscoisesdk/compare/v1.5.1...v2.0.0>`__ - 2022-03-24
 ----------------------------------------------------------------------------------------
@@ -157,7 +176,7 @@ Removed
    and ``RestSession``.
 -  Drop ISE version 3.0.0 support.
 
-.. _section-7:
+.. _section-8:
 
 `1.5.1 <https://github.com/CiscoISE/ciscoisesdk/compare/v1.5.0...v1.5.1>`__ - 2022-02-25
 ----------------------------------------------------------------------------------------
@@ -169,7 +188,7 @@ Changed
 
 -  Update docstring documentation of modules and functions.
 
-.. _section-8:
+.. _section-9:
 
 `1.5.0 <https://github.com/CiscoISE/ciscoisesdk/compare/v1.4.2...v1.5.0>`__ - 2022-02-23
 ----------------------------------------------------------------------------------------
@@ -282,7 +301,7 @@ Added
    ``RestSession``.
 -  New ``additional_data`` property in ``ApiError``.
 
-.. _fixed-4:
+.. _fixed-5:
 
 Fixed
 ~~~~~
@@ -291,12 +310,12 @@ Fixed
    variables set after the module is imported, and not only before it.
 -  Fixed the docstring tables of the API modules.
 
-.. _section-9:
+.. _section-10:
 
 `1.4.2 <https://github.com/CiscoISE/ciscoisesdk/compare/v1.4.1...v1.4.2>`__ - 2022-02-18
 ----------------------------------------------------------------------------------------
 
-.. _fixed-5:
+.. _fixed-6:
 
 Fixed
 ~~~~~
@@ -305,7 +324,7 @@ Fixed
    when they attempt to get_next_page. Previous version only captured
    and ignored 404 Not Found.
 
-.. _section-10:
+.. _section-11:
 
 `1.4.1 <https://github.com/CiscoISE/ciscoisesdk/compare/v1.4.0...v1.4.1>`__ - 2022-01-20
 ----------------------------------------------------------------------------------------
@@ -318,7 +337,7 @@ Changed
 -  Update module inner documentation.
 -  Downgrade requirements file to use poetry versions.
 
-.. _section-11:
+.. _section-12:
 
 `1.4.0 <https://github.com/CiscoISE/ciscoisesdk/compare/v1.3.1...v1.4.0>`__ - 2022-01-19
 ----------------------------------------------------------------------------------------
@@ -330,7 +349,7 @@ Changed
 
 -  Update requirements
 
-.. _fixed-6:
+.. _fixed-7:
 
 Fixed
 ~~~~~
@@ -338,7 +357,7 @@ Fixed
 -  Update pagination, get_next_page inner logic and location from utils
    to pagination.
 
-.. _section-12:
+.. _section-13:
 
 `1.3.1 <https://github.com/CiscoISE/ciscoisesdk/compare/v1.3.0...v1.3.1>`__ - 2021-12-13
 ----------------------------------------------------------------------------------------
@@ -350,7 +369,7 @@ Changed
 
 -  Fixes utils.get_next_page generator starting default page
 
-.. _section-13:
+.. _section-14:
 
 `1.3.0 <https://github.com/CiscoISE/ciscoisesdk/compare/v1.2.0...v1.3.0>`__ - 2021-12-13
 ----------------------------------------------------------------------------------------
@@ -384,7 +403,7 @@ Removed
 -  Removes replication_status module
 -  Removes sync_ise_node module
 
-.. _section-14:
+.. _section-15:
 
 `1.2.0 <https://github.com/CiscoISE/ciscoisesdk/compare/v1.1.0...v1.2.0>`__ - 2021-11-24
 ----------------------------------------------------------------------------------------
@@ -413,7 +432,7 @@ Removed
 
 -  Removes link of 3.1.0 modules to 3.0.0 version
 
-.. _section-15:
+.. _section-16:
 
 `1.1.0 <https://github.com/CiscoISE/ciscoisesdk/compare/v1.0.1...v1.1.0>`__ - 2021-10-22
 ----------------------------------------------------------------------------------------
@@ -433,7 +452,7 @@ Changed
 -  Default ISE DEFAULT_VERSION to 3.1.0
 -  Update documentation to use ISE v3.1.0
 
-.. _section-16:
+.. _section-17:
 
 `1.0.1 <https://github.com/CiscoISE/ciscoisesdk/compare/v1.0.0...v1.0.1>`__ - 2021-09-14
 ----------------------------------------------------------------------------------------
@@ -445,7 +464,7 @@ Changed
 
 -  Disabled warnings of urllib3 if verify is False
 
-.. _section-17:
+.. _section-18:
 
 `1.0.0 <https://github.com/CiscoISE/ciscoisesdk/compare/v0.5.1...v1.0.0>`__ - 2021-07-21
 ----------------------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ciscoisesdk"
-version = "2.0.6"
+version = "2.0.7"
 description = "Cisco Identity Services Engine Platform SDK"
 authors = ["Jose Bogarin Solano <jbogarin@altus.cr>", "William Astorga <wastorga@altus.cr>"]
 license = "MIT"


### PR DESCRIPTION
…ect, v3_1_1.mics.session_disconnect and v3_1_patch_1.mics.session_disconnect

  + From /admin/API/mnt/CoA/Disconnect/{PSN_NAME}/{MAC}/{DISCONNECT_TYPE}/{NAS_IPV4}/{{ENDPOINT_IP}} to /admin/API/mnt/CoA/Disconnect/{PSN_NAME}/{MAC}/{DISCONNECT_TYPE}/{NAS_IPV4}/{ENDPOINT_IP}